### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
           cache-to: type=gha,mode=max
       - name: generate build provenance
         if: ${{ github.event_name != 'pull_request' }}
-        uses: github-early-access/generate-build-provenance@main
+        uses: github-early-access/generate-build-provenance@e9e8ff9e95bfdd79719197569bb666e2889c2e55 # main
         with:
           subject-name: ${{ steps.meta.outputs.tags }}
           subject-digest: ${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,35 +1,33 @@
 name: build-binary
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
-
+    branches: ["main"]
 jobs:
   build:
     permissions:
-        id-token: write
-        packages: write
-        contents: write
+      id-token: write
+      packages: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
-        - name: Check out code
-          uses: actions/checkout@v4
-        - name: Set up Go
-          uses: actions/setup-go@v5
-          with:
-            go-version: '1.21'
-        - name: Run Go build
-          run: |
-            go build -v -o demo-go ./...
-        - name: Sign artifact
-          uses: github-early-access/generate-build-provenance@main
-          with:
-            subject-path: '${{ github.workspace }}/demo-go'
-        - name: Upload artifact
-          uses: actions/upload-artifact@v3
-          with:
-            name: demo-go-binary
-            path: demo-go
+      - name: Check out code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
+        with:
+          go-version: '1.21'
+      - name: Run Go build
+        run: |
+          go build -v -o demo-go ./...
+      - name: Sign artifact
+        uses: github-early-access/generate-build-provenance@e9e8ff9e95bfdd79719197569bb666e2889c2e55 # main
+        with:
+          subject-path: '${{ github.workspace }}/demo-go'
+      - name: Upload artifact
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+        with:
+          name: demo-go-binary
+          path: demo-go


### PR DESCRIPTION
<!-- minder: pr-remediation-body: { "ContentSha": "6cf81521850c1f08abcead73bd6470f8c0e28087" } -->

This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
