### PR TITLE
Handle mixed case names in build-image workflows

### DIFF
--- a/.github/workflows/build-image-signed-cosign-malicious.yml
+++ b/.github/workflows/build-image-signed-cosign-malicious.yml
@@ -8,7 +8,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,6 +40,9 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=daily
 
       - name: Build and push Docker image
         id: build-and-push
@@ -48,16 +50,15 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:daily
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-
       - name: Sign the published Docker image
         env:
+          TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
         run: |
           cosign version
-          echo "ghcr.io/${{ github.repository }}:daily" | xargs -I {} cosign sign --yes {}@${DIGEST}
-          echo "ghcr.io/${{ github.repository }}:latest" | xargs -I {} cosign sign --yes {}@${DIGEST}
+          echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/build-image-signed-cosign-static-copied.yml
+++ b/.github/workflows/build-image-signed-cosign-static-copied.yml
@@ -8,7 +8,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,20 +36,22 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=static
 
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}:static
+          tags: ${{ steps.meta.outputs.tags }}
           context: .
-          file : Dockerfile.static
-
+          file: Dockerfile.static
 
       - name: Sign the published Docker image
         env:
+          TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
         run: |
           cosign version
-          echo "ghcr.io/${{ github.repository }}:static" | xargs -I {} cosign sign --yes {}@${DIGEST}
+          echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/build-image-signed-cosign-static.yml
+++ b/.github/workflows/build-image-signed-cosign-static.yml
@@ -8,7 +8,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,20 +36,22 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=static
 
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}:static
+          tags: ${{ steps.meta.outputs.tags }}
           context: .
-          file : Dockerfile.static
-
+          file: Dockerfile.static
 
       - name: Sign the published Docker image
         env:
+          TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
         run: |
           cosign version
-          echo "ghcr.io/${{ github.repository }}:static" | xargs -I {} cosign sign --yes {}@${DIGEST}
+          echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/build-image-signed-cosign.yml
+++ b/.github/workflows/build-image-signed-cosign.yml
@@ -8,7 +8,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,6 +36,9 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=daily
 
       - name: Build and push Docker image
         id: build-and-push
@@ -44,16 +46,15 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:daily
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-
       - name: Sign the published Docker image
         env:
+          TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
         run: |
           cosign version
-          echo "ghcr.io/${{ github.repository }}:daily" | xargs -I {} cosign sign --yes {}@${DIGEST}
-          echo "ghcr.io/${{ github.repository }}:latest" | xargs -I {} cosign sign --yes {}@${DIGEST}
+          echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/build-image-signed-ghat-malicious.yml
+++ b/.github/workflows/build-image-signed-ghat-malicious.yml
@@ -2,6 +2,10 @@ name: image-signed-ghat(latest)-malicious
 on:
   workflow_dispatch:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,6 +20,8 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: The malicious step
+        env:
+          IMAGE_NAME: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         run: |
           make build-malicious-image
 
@@ -26,12 +32,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+
       - name: Build and push image
         id: push-step
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
           context: .
 
       - name: Attest image
@@ -39,3 +53,4 @@ jobs:
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push-step.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build-image-signed-ghat-static-copied.yml
+++ b/.github/workflows/build-image-signed-ghat-static-copied.yml
@@ -2,6 +2,10 @@ name: image-signed-ghat(static)-copied
 on:
   workflow_dispatch:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,17 +26,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=static
+
       - name: Build and push image
         id: push-step
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}:static
+          tags: ${{ steps.meta.outputs.tags }}
           context: .
-          file : Dockerfile.static
+          file: Dockerfile.static
 
       - name: Attest image
         uses: actions/attest-build-provenance@v1.4.1
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push-step.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build-image-signed-ghat-static.yml
+++ b/.github/workflows/build-image-signed-ghat-static.yml
@@ -2,6 +2,10 @@ name: image-signed-ghat(static)
 on:
   workflow_dispatch:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,17 +26,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=static
+
       - name: Build and push image
         id: push-step
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}:static
+          tags: ${{ steps.meta.outputs.tags }}
           context: .
-          file : Dockerfile.static
+          file: Dockerfile.static
 
       - name: Attest image
         uses: actions/attest-build-provenance@v1.4.1
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push-step.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build-image-signed-ghat.yml
+++ b/.github/workflows/build-image-signed-ghat.yml
@@ -2,6 +2,10 @@ name: image-signed-ghat(latest)
 on:
   workflow_dispatch:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,12 +26,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+
       - name: Build and push image
         id: push-step
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
           context: .
 
       - name: Attest image
@@ -35,3 +47,4 @@ jobs:
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push-step.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build-image-unsigned.yml
+++ b/.github/workflows/build-image-unsigned.yml
@@ -8,7 +8,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,11 +17,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-
-#      - name: Install Cosign
-#        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 #v3.1.1
-#        with:
-#          cosign-release: 'v2.1.1'
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
@@ -39,6 +33,9 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=daily
 
       - name: Build and push Docker image
         id: build-and-push
@@ -46,14 +43,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:daily
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-#      - name: Sign the published Docker image
-#        env:
-#          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-#        run: |
-#          echo "ghcr.io/${{ github.repository }}:daily" | xargs -I {} cosign sign --yes {}@${DIGEST}
-#          echo "ghcr.io/${{ github.repository }}:latest" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Replace this with your image name, i.e. ghcr.io/<your-username>/demo-repo-go:latest
 IMAGE_NAME?=ghcr.io/stacklok/demo-repo-go:latest
 
+# Lowercase the image name to handle mixed-case GitHub org/repo names
+IMAGE_NAME := $(shell echo $(IMAGE_NAME) | tr '[:upper:]' '[:lower:]')
+
 # Replace this with your GitHub username and PAT.
 # This is used to authenticate with GitHub Container Registry (GHCR)
 # and push the image to your repository.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 ## Overview
 
 The `demo-repo-go` project is a repository template primarily intended for testing and
-demonstration purposes with stacklok projects. It is a simple Go project that allows you to
+demonstration purposes with Stacklok projects. It is a simple Go project that allows you to
 quickly get started with testing and demonstrating how you can use Minder and Trusty with
 your Go projects. It features continuous integration (CI) workflows that demonstrate how to 
 build, test, and sign artifacts using Sigstore and GitHub Attestations. 
-
 
 ## Features
 
@@ -15,18 +14,21 @@ build, test, and sign artifacts using Sigstore and GitHub Attestations.
 - Dockerfile for building a container image
 
 GitHub Actions workflows for:
+
 - Producing signed and unsigned artifacts using Sigstore and GitHub attestations API
 - Producing artifacts such as container images and binaries
 - Producing container images that are reproducible (always the same digest)
 - Producing "malicious" container images for testing purposes (e.g., code content was altered while building the image)
 
 Makefile targets for simulating out-of-band signing of artifacts (both intended and not):
+
 - Generating signed container images and "malicious" images
 - Pushing container images to container registry (GHCR)
 - Generating a local key pair for signing container images
 - Sign container images using Sigstore by using a local key pair or by going through the Sigstore OIDC sign-in flow
 
 Branches:
+
 - Set of pre-created branches to use for opening PRs each demonstrating a different feature or use case with Minder and Trusty
 
 ## How to Use This Template


### PR DESCRIPTION
The workflows fail if the GitHub organization name or repository name use mixed case (such as the Stacklok-Demo-Org), since Docker only allows lower-cased image names.

Updated to use the docker/metadata-action tags output since that action handles the normalization.

Also had to handle in the Makefile for the "malicious" steps.